### PR TITLE
Replace ftp download with http

### DIFF
--- a/install-libxl.js
+++ b/install-libxl.js
@@ -1,19 +1,19 @@
 /**
  * The MIT License (MIT)
- * 
+ *
  * Copyright (c) 2013 Christian Speckner <cnspeckn@googlemail.com>,
  *                    Torben Fitschen <teddyttn@gmail.com>
- * 
+ *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- * 
+ *
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -23,246 +23,58 @@
  * THE SOFTWARE.
  */
 
+VERSION = '3.6.1';
+
 var fs = require('fs'),
-    Ftp = require('ftp'),
     os = require('os'),
     path = require('path'),
-    tmp = require('tmp'),
-    spawn = require('child_process').spawn,
     util = require('util'),
-    md5 = require('MD5');
+    request = require('request'),
+    tar = require('tar'),
+    zlib = require('zlib');
 
-var isWin = !!os.platform().match(/^win/),
-    isMac = !!os.platform().match(/^darwin/),
-    dependencyDir = 'deps',
-    libxlDir = path.join(dependencyDir, 'libxl'),
-    ftpHost = 'xlware.com';
+var dependencyDir = 'deps',
+    libxlDir = path.join(dependencyDir, 'libxl');
 
-var download = function(callback) {
-    var ftpClient = new Ftp();
+function getPlatform() {
+  if (os.platform().match(/^win/)) {
+    return 'win';
+  }else if (os.platform().match(/^linux/)) {
+    return 'lin';
+  }else if (os.platform().match(/^darwin/)) {
+    return 'mac';
+  }
 
-    function decodeDirectoryEntry(entry) {
-        var match = entry.name.match(/^libxl-(\w+)-([\d\.]+)\.([a-zA-z\.]+)$/);
-        if (match) {
-            return {
-                file: entry.name,
-                system: match[1],
-                version: match[2],
-                suffix: match[3]
-            };
-        }
-    }
+  throw new Error('Unsupported platform');
+}
 
-    function decodeVersion(file) {
-        return file.version.split('.');
-    }
-
-    function compareFiles(file1, file2) {
-        function cmp(a, b) {
-            if (a > b) return -1;
-            if (a < b) return  1;
-            return 0;
-        }
-
-        var v1 = decodeVersion(file1), v2 = decodeVersion(file2),
-            nibbles = Math.min(v1.length, v2.length),
-            partialResult;
-
-        for (var i = 0; i < nibbles; i++) {
-            partialResult = cmp(v1[i], v2[i]);
-
-            if (partialResult) return partialResult;
-        }
-
-        return v1.length > nibbles ? -1 : 1;
-    }
-
-    function validArchive(file) {
-        if (isWin) {
-            return file.system === "win" && file.suffix === "zip";
-        } else if (isMac) {
-            return file.system === "mac" && file.suffix === "tar.gz";
-        }
-        return file.system === "lin" && file.suffix === "tar.gz";
-    }
-
-    function onError(error) {
-        console.log('Download from FTP failed');
-        throw(error);
-    }
-
-    function onReady() {
-        console.log('Connected, receiving directory list...');
-
-        ftpClient.list(function(error, list) {
-            if (error) onError(error);
-
-            processDirectoryList(list);
-        });
-    }
-
-    function processDirectoryList(list) {
-        try {
-            if (!list) throw new Error('FTP list failed');
-
-            var candidates = list
-                .map(decodeDirectoryEntry)
-                .filter(validArchive)
-                .sort(compareFiles);
-
-            if (!candidates.length) throw new Error('Failed to identify a suitable download');
-
-            download(candidates[0].file);
-        } catch (error) {
-            console.log(error.message);
-        }
-    }
-
-    /*
-     * There is a obscure bug concerning ftp.get and stream.pipe, leading to
-     * occasional gobbled chunks at the end of the download
-     *
-     * https://github.com/mscdex/node-ftp/issues/70
-     *
-     * Thus, we handle the download manually and compute MD5 and total size to
-     * get meaningful debug output.
-     */
-    function consumeDownload(instream, outstream, callback) {
-        var chunks = [],
-            instreamTerminated = false,
-            outstreamTerminated = false,
-            buffering = false,
-            chunkIdx = 0,
-            totalSize = 0;
-
-        function write() {
-            return outstream.write(chunks[chunkIdx++]);
-        }
-
-        function terminateOutstream() {
-            if (!outstreamTerminated) outstream.end();
-            outstreamTerminated = true;
-        }
-
-        instream.on('data', function(chunk) {
-            chunks.push(chunk);
-            totalSize += chunk.length;
-            if (!buffering) buffering = !write();
-        });
-
-        instream.on('end', function() {
-            instreamTerminated = true;
-            if (!buffering) terminateOutstream();
-        });
-
-        outstream.on('drain', function() {
-            // Write chunks until the queue is empty or the the writer get
-            // overwhelmed.
-            while ((buffering = chunkIdx < chunks.length) && write());
-
-            // Stop buffering if all chunks have been flushed.
-            if (!buffering && instreamTerminated) terminateOutstream();
-        });
-
-        outstream.on('close', function() {
-            callback(undefined, totalSize, md5(Buffer.concat(chunks), totalSize));
-        });
-    }
-
-    function download(name) {
-        console.log('Downloading ' + name + '...');
-
-        tmp.tmpName({
-            postfix: path.basename(name),
-            tries: 10
-        }, function(err, outfile) {
-            if (err) throw err;
-
-            var writer = fs.createWriteStream(outfile);
-            writer.on('error', onError);
-
-            function onOpen() {
-                ftpClient.get(name, function(error, stream) {
-                    if (error) throw error;
-
-                    stream.on('error', onError);
-                    consumeDownload(stream, writer, function(err, bytes, hash) {
-                        if (err) throw err;
-
-                        ftpClient.end();
-
-                        console.log(util.format('Download complete - %s bytes, MD5: %s',
-                            bytes, hash));
-                        callback(outfile);
-                    });
-                });
-            }
-
-            writer.on('open', onOpen);
-        });        
-    }
-
-    ftpClient.on('error', onError);
-    ftpClient.on('ready', onReady);
-
-    console.log('Connecting to ftp://' + ftpHost + '...');
-
-    ftpClient.connect({
-        host: ftpHost
+function download() {
+  var file = util.format('libxl-%s-%s', getPlatform(), VERSION);
+  var url = util.format('http://www.libxl.com/download/%s.tar.gz', file);
+  // the env has priority
+  url = process.env.LIBXL_DOWNLOAD_URL || url;
+  console.log('Downloading ' + url);
+  request.get(url)
+    .pipe(zlib.createGunzip())
+    .pipe(tar.Extract({
+      path: libxlDir,
+      strip: 1
+    }))
+    .on('error', function(err) {
+      throw err;
+    })
+    .on('end', function() {
+      console.log('All done!');
     });
-};
-
-var execute = function(cmd, args, callback) {
-    spawn(cmd, args).on('close', function(code) {
-        if (0 === code) {
-            callback();
-        } else {
-            process.exit(1);
-        }
-    });
-};
-
-var extractor = function(file, target, callback) {
-    console.log('Extracting ' + file + ' ...');
-
-    if (isWin) {
-        execute(path.join('tools', '7zip', '7za.exe'), ['x', file, '-o' + dependencyDir], callback);
-    } else {
-        execute('tar', ['-C', dependencyDir, '-zxf', file], callback);
-    }
-};
-
-var finder = function(dir, pattern) {
-  var files = fs.readdirSync(dir),
-      i,
-      file;
-    for (i = 0; i < files.length; i++) {
-        file = files[i];
-        if (file.match(pattern)) {
-            return path.join(dir, file);
-        }
-    }
-    return null;
-};
+}
 
 if (fs.existsSync(libxlDir)) {
-    console.log('Libxl already downloaded, nothing to do');
-    process.exit(0);
+  console.log('Libxl already downloaded, nothing to do');
+  process.exit(0);
 }
 
 if (!fs.existsSync(dependencyDir)) {
-    fs.mkdirSync(dependencyDir);
+  fs.mkdirSync(dependencyDir);
 }
 
-download(function(archive) {
-    extractor(archive, dependencyDir, function() {
-        fs.unlinkSync(archive);
-
-        var extractedDir = finder(dependencyDir, /^libxl/);
-        console.log('Renaming ' + extractedDir + ' to ' + libxlDir + ' ...');
-
-        fs.renameSync(extractedDir, libxlDir);
-
-        console.log('All done!');
-    });
-});
+download();

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "url": "https://github.com/DirtyHairy/node-libxl/issues"
   },
   "engines": {
-    "node": ">=0.10"
+    "node": ">=0.10",
+    "iojs": ">=1.0.0"
   },
   "main": "./lib/libxl.js",
   "gypfile": true,
@@ -27,8 +28,7 @@
   },
   "dependencies": {
     "nan": "~1.5.1",
-    "ftp": "~0.3.0",
-    "tmp": "~0.0.24",
-    "MD5": "~1.2.1"
+    "request": "^2.53.0",
+    "tar": "^1.0.3"
   }
 }


### PR DESCRIPTION
Additionally the install will check for the environmental variable `LIBXL_DOWNLOAD_URL` that can override the default url for the platform.
For instance: `LIBXL_DOWNLOAD_URL=http://localhost/libxl.tar.gz npm install`